### PR TITLE
Fix models representation

### DIFF
--- a/shodAND/base/models.py
+++ b/shodAND/base/models.py
@@ -6,13 +6,23 @@ class Host(models.Model):
     creation_date = models.DateTimeField('date created')
     modification_date = models.DateTimeField('date modified')
 
+    def __str__(self):
+        return f"{self.ip}"
+
 class Port(models.Model):
     port = models.IntegerField()
     creation_date = models.DateTimeField('date created')
     modification_date = models.DateTimeField('date modified')
+
+    def __str__(self):
+        return f"{self.port}"
+
 
 class Scan(models.Model):
     host = models.ForeignKey(Host, on_delete=models.CASCADE)
     ports = models.ManyToManyField(Port)
     creation_date = models.DateTimeField('date created')
     modification_date = models.DateTimeField('date modified')
+
+    def __str__(self):
+        return f"{self.host} [{self.ports}]"

--- a/shodAND/base/models.py
+++ b/shodAND/base/models.py
@@ -9,6 +9,9 @@ class Host(models.Model):
     def __str__(self):
         return f"{self.ip}"
 
+    def __repr__(self):
+        return f"<Host {self.ip}>"
+
 class Port(models.Model):
     port = models.IntegerField()
     creation_date = models.DateTimeField('date created')
@@ -16,6 +19,9 @@ class Port(models.Model):
 
     def __str__(self):
         return f"{self.port}"
+
+    def __repr__(self):
+        return f"<Port {self.port}>"
 
 
 class Scan(models.Model):
@@ -26,3 +32,6 @@ class Scan(models.Model):
 
     def __str__(self):
         return f"{self.host} [{self.ports}]"
+
+    def __repr__(self):
+        return f"<Scan {self.host} [{self.ports}]>"

--- a/shodAND/shodAND/settings.py
+++ b/shodAND/shodAND/settings.py
@@ -69,6 +69,14 @@ TEMPLATES = [
     },
 ]
 
+
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAdminUser',
+    ],
+    'PAGE_SIZE': 10,
+}
+
 WSGI_APPLICATION = 'shodAND.wsgi.application'
 
 


### PR DESCRIPTION
It fixes the model representation for each available model. It includes string and instance representation.

Equivalences:

model | repr | string 
--- | --- | ---
host | <Host $IP> | "$IP"
port | <Port $IP> | "$port"
scan | <Scan $host [$IP]> | "$host [$ports]"


Fix #4 Models representation 
