### PR TITLE
API pagination

### DIFF
--- a/shodAND/shodAND/settings.py
+++ b/shodAND/shodAND/settings.py
@@ -74,7 +74,8 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAdminUser',
     ],
-    'PAGE_SIZE': 10,
+    'PAGE_SIZE': 50,
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
 }
 
 WSGI_APPLICATION = 'shodAND.wsgi.application'


### PR DESCRIPTION
It activates API pagination with
- 50 elements per page
- integrated controls:
  - "count", "next" and "previous" parameters are integrated with each
response.
  - Now the real response will be integrated inside "result" property.

Fix #15 Integrate pagination for API